### PR TITLE
Improve Linux Documentation

### DIFF
--- a/docs/dfu.md
+++ b/docs/dfu.md
@@ -46,9 +46,12 @@
 
 ## Linux
 
-* Download the [dfu-util](http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/).
-	
-* Suggest you to put the dfu-util.exe to your downloaded Duo firmware folder.
+* Download the [dfu-util](http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/) or use
+  the package manager of your distribution to get the latest version:
+
+		$ sudo apt-get install dfu-util
+
+* If you download dfu-util we suggest putting the binary into the Duo firmware folder.
 
 
 ## Check Version

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -32,32 +32,32 @@ From the command line:
 
 To update System-Part1
 
-$ dfu-util -d 2b04:d058 -a 0 -s 0x08020000 -D duo-system-part1.bin
+$ sudo dfu-util -d 2b04:d058 -a 0 -s 0x08020000 -D duo-system-part1.bin
 
 To update System-Part2
 
-$ dfu-util -d 2b04:d058 -a 0 -s 0x08040000 -D duo-system-part2.bin
+$ sudo dfu-util -d 2b04:d058 -a 0 -s 0x08040000 -D duo-system-part2.bin
 
 
 ## Updating Factory Reset Firmware
 
 To update factory reset image
 
-$ dfu-util -d 2b04:d058 -a 2 -s 0x140000 -D duo-fac-tinker.bin
+$ sudo dfu-util -d 2b04:d058 -a 2 -s 0x140000 -D duo-fac-tinker.bin
 
 
 ## Updating User Firmware
 
 To update User-Part
 
-$ dfu-util -d 2b04:d058 -a 0 -s 0x080C0000 -D duo-user-part.bin
+$ sudo dfu-util -d 2b04:d058 -a 0 -s 0x080C0000 -D duo-user-part.bin
 
 
 ## Dumping Firmware
 
 You can dump the firmware to your computer, for example, to backup the DCT to a file (duo-dct-dump.bin):
 
-$ dfu-util -d 2b04:d058 -a 0 -s 0x08004000 -U duo-dct-dump.bin
+$ sudo dfu-util -d 2b04:d058 -a 0 -s 0x08004000 -U duo-dct-dump.bin
 
 After updating the firmware, press the reset button to run the new firmware.
 


### PR DESCRIPTION
Extended the documentation regarding dfu-util and firmware flashing:
- dfu-util needs root permissions on Linux
- Link to dfu-util does not work on x64 systems. Added suggestion to get recent version through package manager.